### PR TITLE
Use clientcmd's built-in flag handling

### DIFF
--- a/pkg/subctl/cmd/cloud/cleanup/aws.go
+++ b/pkg/subctl/cmd/cloud/cleanup/aws.go
@@ -44,7 +44,7 @@ func newAWSCleanupCommand() *cobra.Command {
 }
 
 func cleanupAws(cmd *cobra.Command, args []string) {
-	err := cloudutils.RunOnAWS(infraID, region, "", *kubeConfig, *kubeContext,
+	err := cloudutils.RunOnAWS(infraID, region, "", clientConfig,
 		func(cloud api.Cloud, reporter api.Reporter) error {
 			return cloud.CleanupAfterSubmariner(reporter)
 		})

--- a/pkg/subctl/cmd/cloud/cleanup/cleanup.go
+++ b/pkg/subctl/cmd/cloud/cleanup/cleanup.go
@@ -18,17 +18,16 @@ package cleanup
 
 import (
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
-	kubeConfig  *string
-	kubeContext *string
+	clientConfig *clientcmd.ClientConfig
 )
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
-	kubeConfig = origKubeConfig
-	kubeContext = origKubeContext
+func NewCommand(origClientConfig *clientcmd.ClientConfig) *cobra.Command {
+	clientConfig = origClientConfig
 	cmd := &cobra.Command{
 		Use:   "cleanup",
 		Short: "Clean up the cloud",

--- a/pkg/subctl/cmd/cloud/cloud.go
+++ b/pkg/subctl/cmd/cloud/cloud.go
@@ -20,18 +20,19 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/cleanup"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/prepare"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
+func NewCommand(clientConfig *clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cloud",
 		Short: "Cloud operations",
 		Long:  `This command contains cloud operations related to Submariner installation.`,
 	}
 
-	cmd.AddCommand(prepare.NewCommand(origKubeConfig, origKubeContext))
-	cmd.AddCommand(cleanup.NewCommand(origKubeConfig, origKubeContext))
+	cmd.AddCommand(prepare.NewCommand(clientConfig))
+	cmd.AddCommand(cleanup.NewCommand(clientConfig))
 
 	return cmd
 }

--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -58,7 +58,7 @@ func prepareAws(cmd *cobra.Command, args []string) {
 		},
 		Gateways: gateways,
 	}
-	err := cloudutils.RunOnAWS(infraID, region, gwInstanceType, *kubeConfig, *kubeContext,
+	err := cloudutils.RunOnAWS(infraID, region, gwInstanceType, clientConfig,
 		func(cloud api.Cloud, reporter api.Reporter) error {
 			return cloud.PrepareForSubmariner(input, reporter)
 		})

--- a/pkg/subctl/cmd/cloud/prepare/prepare.go
+++ b/pkg/subctl/cmd/cloud/prepare/prepare.go
@@ -18,6 +18,7 @@ package prepare
 
 import (
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
@@ -25,14 +26,12 @@ var (
 	natDiscoveryPort uint16
 	vxlanPort        uint16
 	metricsPort      uint16
-	kubeConfig       *string
-	kubeContext      *string
+	clientConfig     *clientcmd.ClientConfig
 )
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
-	kubeConfig = origKubeConfig
-	kubeContext = origKubeContext
+func NewCommand(origClientConfig *clientcmd.ClientConfig) *cobra.Command {
+	clientConfig = origClientConfig
 	cmd := &cobra.Command{
 		Use:   "prepare",
 		Short: "Prepare the cloud",

--- a/pkg/subctl/cmd/cloud/utils/aws.go
+++ b/pkg/subctl/cmd/cloud/utils/aws.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -47,12 +48,12 @@ func AddAWSFlags(command *cobra.Command, infraID, region *string) {
 
 // RunOnAWS runs the given function on AWS, supplying it with a cloud instance connected to AWS and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to AWS.
-func RunOnAWS(infraID, region, gwInstanceType, kubeConfig, kubeContext string,
+func RunOnAWS(infraID, region, gwInstanceType string, clientConfig *clientcmd.ClientConfig,
 	function func(cloud api.Cloud, reporter api.Reporter) error) error {
 	utils.ExpectFlag(infraIDFlag, infraID)
 	utils.ExpectFlag(regionFlag, region)
 
-	k8sConfig, err := utils.GetRestConfig(kubeConfig, kubeContext)
+	k8sConfig, err := (*clientConfig).ClientConfig()
 	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
 
 	reporter := NewCLIReporter()

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -106,7 +106,7 @@ var deployBroker = &cobra.Command{
 		if valid, err := isValidGlobalnetConfig(); !valid {
 			exitOnError("Invalid GlobalCIDR configuration", err)
 		}
-		config, err := getRestConfig(kubeConfig, kubeContext)
+		config, err := getRestConfig()
 		exitOnError("The provided kubeconfig is invalid", err)
 
 		status := cli.NewStatus()

--- a/pkg/subctl/cmd/export.go
+++ b/pkg/subctl/cmd/export.go
@@ -62,7 +62,7 @@ func exportService(cmd *cobra.Command, args []string) {
 	err := validateArguments(args)
 	exitOnError("Insufficient arguments", err)
 
-	clientConfig := getClientConfig(kubeConfig, kubeContext)
+	clientConfig := getClientConfig()
 	restConfig, err := clientConfig.ClientConfig()
 
 	exitOnError("Error connecting to the target cluster", err)

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -147,8 +147,8 @@ var joinCmd = &cobra.Command{
 		exitOnError("Error connecting to broker cluster", err)
 		err = isValidCustomCoreDNSConfig()
 		exitOnError("Invalid Custom CoreDNS configuration", err)
-		config := getClientConfig(kubeConfig, kubeContext)
-		joinSubmarinerCluster(config, kubeContext, subctlData)
+		config := getClientConfig()
+		joinSubmarinerCluster(config, subctlData)
 	},
 }
 
@@ -161,7 +161,7 @@ func checkArgumentPassed(args []string) error {
 
 var status = cli.NewStatus()
 
-func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, subctlData *datafile.SubctlData) {
+func joinSubmarinerCluster(config clientcmd.ClientConfig, subctlData *datafile.SubctlData) {
 	// Missing information
 	var qs = []*survey.Question{}
 
@@ -169,7 +169,7 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 		rawConfig, err := config.RawConfig()
 		// This will be fatal later, no point in continuing
 		exitOnError("Error connecting to the target cluster", err)
-		clusterName := getClusterNameFromContext(rawConfig, contextName)
+		clusterName := getClusterNameFromContext(rawConfig)
 		if clusterName != nil {
 			clusterID = *clusterName
 		}

--- a/pkg/subctl/cmd/show.go
+++ b/pkg/subctl/cmd/show.go
@@ -55,7 +55,7 @@ func getClientConfigAndClusterName(rules *clientcmd.ClientConfigLoadingRules, ov
 		return restConfig{}, err
 	}
 
-	clusterName := getClusterNameFromContext(raw, overrides.CurrentContext)
+	clusterName := getClusterNameFromContext(raw)
 
 	if clusterName == nil {
 		return restConfig{}, fmt.Errorf("could not obtain the cluster name from kube config: %#v", raw)

--- a/pkg/subctl/cmd/utils/utils.go
+++ b/pkg/subctl/cmd/utils/utils.go
@@ -21,8 +21,6 @@ import (
 	"os"
 
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/version"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // PanicOnError will print the subctl version and then panic in case of an actual error
@@ -49,25 +47,6 @@ func ExitWithErrorMsg(message string) {
 	version.PrintSubctlVersion(os.Stderr)
 	fmt.Fprintln(os.Stderr, "")
 	os.Exit(1)
-}
-
-// GetRestConfig returns a rest.Config to use when communicating with K8s
-func GetRestConfig(kubeConfigPath, kubeContext string) (*rest.Config, error) {
-	return GetClientConfig(kubeConfigPath, kubeContext).ClientConfig()
-}
-
-// GetClientConfig returns a clientcmd.ClientConfig to use when communicating with K8s
-func GetClientConfig(kubeConfigPath, kubeContext string) clientcmd.ClientConfig {
-	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	rules.ExplicitPath = kubeConfigPath
-
-	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
-	if kubeContext != "" {
-		overrides.CurrentContext = kubeContext
-	}
-
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
 }
 
 // ExpectFlag exits with an error if the flag value is empty

--- a/pkg/subctl/cmd/validate_tunnel.go
+++ b/pkg/subctl/cmd/validate_tunnel.go
@@ -64,10 +64,12 @@ func init() {
 }
 
 func validateTunnelConfig(cmd *cobra.Command, args []string) {
-	localCfg, err := getRestConfig(args[0], "")
+	// This is wrong
+	localCfg, err := getRestConfig()
 	exitOnError("The provided local kubeconfig is invalid", err)
 
-	remoteCfg, err := getRestConfig(args[1], "")
+	// This is wrong
+	remoteCfg, err := getRestConfig()
 	exitOnError("The provided remote kubeconfig is invalid", err)
 
 	validationStatus := validateTunnelConfigAcrossClusters(localCfg, remoteCfg)

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -193,9 +193,9 @@ func configureTestingFramework(args []string) error {
 }
 
 func clusterNameFromConfig(kubeConfigPath, kubeContext string) string {
-	rawConfig, err := getClientConfig(kubeConfigPath, "").RawConfig()
+	rawConfig, err := getClientConfig().RawConfig()
 	exitOnError(fmt.Sprintf("Error obtaining the kube config for path %q", kubeConfigPath), err)
-	cluster := getClusterNameFromContext(rawConfig, kubeContext)
+	cluster := getClusterNameFromContext(rawConfig)
 	if cluster == nil {
 		exitWithErrorMsg(fmt.Sprintf("Could not obtain the cluster name from kube config: %#v", rawConfig))
 	}


### PR DESCRIPTION
This reduces the amount of flag-handling code we need to carry,
shields us from changes to clientcmd, and enables a host of other
flags which can be useful to connect to Kubernetes clusters.

Signed-off-by: Stephen Kitt <skitt@redhat.com>