### PR TITLE
Configure monitoring as a core service on OCP

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -29,6 +29,8 @@ resources:
   - networkplugin_syncer/service_account.yaml
   - networkplugin_syncer/cluster_role.yaml
   - networkplugin_syncer/cluster_role_binding.yaml
+  - submariner-metrics-reader/role.yaml
+  - submariner-metrics-reader/role_binding.yaml
 # - leader_election/leader_election_role.yaml
 # - leader_election/leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable

--- a/config/rbac/submariner-metrics-reader/role.yaml
+++ b/config/rbac/submariner-metrics-reader/role.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: submariner-metrics-reader
+  namespace: submariner-operator
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]

--- a/config/rbac/submariner-metrics-reader/role_binding.yaml
+++ b/config/rbac/submariner-metrics-reader/role_binding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-submariner-metrics
+  namespace: submariner-operator
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  kind: Role
+  name: submariner-metrics-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/submariner-operator/cluster_role.yaml
+++ b/config/rbac/submariner-operator/cluster_role.yaml
@@ -54,3 +54,18 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 
 	"github.com/submariner-io/submariner-operator/controllers/helpers"
+	"github.com/submariner-io/submariner-operator/pkg/metrics"
 
 	"github.com/go-logr/logr"
-	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.57
 	github.com/coreos/go-semver v0.3.0
+	github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc
 	github.com/go-errors/errors v1.2.0 // indirect
 	github.com/go-logr/logr v0.4.0
 	github.com/go-openapi/spec v0.20.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -175,10 +175,7 @@ github.com/aws/aws-sdk-go v1.23.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.38.46 h1:voiwaKmwU1K6Y0dfjqTSiy5xOG4LPyr5sHD92cj+g2c=
-github.com/aws/aws-sdk-go v1.38.46/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.38.51 h1:aKQmbVbwOCuQSd8+fm/MR3bq0QOsu9Q7S+/QEND36oQ=
-github.com/aws/aws-sdk-go v1.38.51/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.57 h1:Jo6uOnWNbj4jL/8t/XUrHOKm1J6pPcYFhGzda20UcUk=
 github.com/aws/aws-sdk-go v1.38.57/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
@@ -1254,10 +1251,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/submariner-io/admiral v0.10.0-m1/go.mod h1:2kkQieEpnEAMHDw4e1wSKUQ5Z3ArycrfD3B6gXaSTDo=
 github.com/submariner-io/admiral v0.10.0-m1.0.20210602113843-3b8dfd67945b h1:OM2iJnKPtaJjLChHcmOpM9j3tFasSVEWDKGVVYfqvn8=
 github.com/submariner-io/admiral v0.10.0-m1.0.20210602113843-3b8dfd67945b/go.mod h1:oE3hQZJMvB8j9wHyLBZYmupCZK/G83z36QMgTn2vUlE=
-github.com/submariner-io/cloud-prepare v0.10.0-m1 h1:OObZkf5GvN+aY39W2PudgTV53YvEFtfWhpU2aq8sFO0=
-github.com/submariner-io/cloud-prepare v0.10.0-m1/go.mod h1:lJB0LIymlcy1qX9PMYvk1UPb3jGdJ+zZsMmhqC+Ow4M=
-github.com/submariner-io/cloud-prepare v0.10.0-m1.0.20210608112354-a7dbf3041108 h1:ll3N16sgiNn2Bx/JGC5cEufxrPFIsfYbRYhxJP6Oi9g=
-github.com/submariner-io/cloud-prepare v0.10.0-m1.0.20210608112354-a7dbf3041108/go.mod h1:JckHebIHYaKRSHWfpAbrytszJ3MCARXpmnAGX4vIB/A=
 github.com/submariner-io/cloud-prepare v0.10.0-m1.0.20210609164526-e3506b211821 h1:m0LbbWQdCstRmcDrgw0zAh9SNPp5f/+8xX5CT8kLwJU=
 github.com/submariner-io/cloud-prepare v0.10.0-m1.0.20210609164526-e3506b211821/go.mod h1:MIyklqMw+8oWO8j15BKbBPZULB1PR8iwFtZL8kwQnvE=
 github.com/submariner-io/lighthouse v0.10.0-m1 h1:VyXJYe1M4YqIG55WdIs4wXzVswcn6yvoviNSY6CJ2TU=

--- a/pkg/discovery/network/network.go
+++ b/pkg/discovery/network/network.go
@@ -43,7 +43,6 @@ func (cn *ClusterNetwork) Show() {
 	if cn == nil {
 		fmt.Println("    No network details discovered")
 	} else {
-		fmt.Printf("    Discovered network details:\n")
 		fmt.Printf("        Network plugin:  %s\n", cn.NetworkPlugin)
 		fmt.Printf("        Service CIDRs:   %v\n", cn.ServiceCIDRs)
 		fmt.Printf("        Cluster CIDRs:   %v\n", cn.PodCIDRs)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright Contributors to the Submariner project.
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("metrics")
+
+const (
+	// OperatorPortName defines the default operator metrics port name used in the metrics Service.
+	OperatorPortName = "http-metrics"
+	// CRPortName defines the custom resource specific metrics' port name used in the metrics Service.
+	CRPortName = "cr-metrics"
+)
+
+// CreateMetricsService creates a Kubernetes Service to expose the passed metrics
+// port(s) with the given name(s).
+func CreateMetricsService(ctx context.Context, cfg *rest.Config, servicePorts []v1.ServicePort) (*v1.Service, error) {
+	if len(servicePorts) < 1 {
+		return nil, fmt.Errorf("failed to create metrics Serice; service ports were empty")
+	}
+	client, err := crclient.New(cfg, crclient.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new client: %w", err)
+	}
+	s, err := initOperatorService(ctx, client, servicePorts)
+	if err != nil {
+		if err == k8sutil.ErrNoNamespace || err == k8sutil.ErrRunLocal {
+			log.Info("Skipping metrics Service creation; not running in a cluster.")
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to initialize service object for metrics: %w", err)
+	}
+	service, err := createOrUpdateService(ctx, client, s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create or get service for metrics: %w", err)
+	}
+
+	return service, nil
+}
+
+func createOrUpdateService(ctx context.Context, client crclient.Client, s *v1.Service) (*v1.Service, error) {
+	if err := client.Create(ctx, s); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+		// Service already exists, we want to update it
+		// as we do not know if any fields might have changed.
+		existingService := &v1.Service{}
+		err := client.Get(ctx, types.NamespacedName{
+			Name:      s.Name,
+			Namespace: s.Namespace,
+		}, existingService)
+		if err != nil {
+			return nil, err
+		}
+
+		s.ResourceVersion = existingService.ResourceVersion
+		if existingService.Spec.Type == v1.ServiceTypeClusterIP {
+			s.Spec.ClusterIP = existingService.Spec.ClusterIP
+		}
+		err = client.Update(ctx, s)
+		if err != nil {
+			return nil, err
+		}
+		log.Info("Metrics Service object updated", "Service.Name",
+			s.Name, "Service.Namespace", s.Namespace)
+		return s, nil
+	}
+
+	log.Info("Metrics Service object created", "Service.Name",
+		s.Name, "Service.Namespace", s.Namespace)
+	return s, nil
+}
+
+// initOperatorService returns the static service which exposes specified port(s).
+func initOperatorService(ctx context.Context, client crclient.Client, sp []v1.ServicePort) (*v1.Service, error) {
+	operatorName, err := k8sutil.GetOperatorName()
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return nil, err
+	}
+	label := map[string]string{"name": operatorName}
+
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-metrics", operatorName),
+			Namespace: namespace,
+			Labels:    label,
+		},
+		Spec: v1.ServiceSpec{
+			Ports:    sp,
+			Selector: label,
+		},
+	}
+
+	ownRef, err := getPodOwnerRef(ctx, client, namespace)
+	if err != nil {
+		return nil, err
+	}
+	service.SetOwnerReferences([]metav1.OwnerReference{*ownRef})
+
+	return service, nil
+}
+
+func getPodOwnerRef(ctx context.Context, client crclient.Client, ns string) (*metav1.OwnerReference, error) {
+	// Get current Pod the operator is running in
+	pod, err := k8sutil.GetPod(ctx, client, ns)
+	if err != nil {
+		return nil, err
+	}
+	podOwnerRefs := metav1.NewControllerRef(pod, pod.GroupVersionKind())
+	// Get Owner that the Pod belongs to
+	ownerRef := metav1.GetControllerOf(pod)
+	finalOwnerRef, err := findFinalOwnerRef(ctx, client, ns, ownerRef)
+	if err != nil {
+		return nil, err
+	}
+	if finalOwnerRef != nil {
+		return finalOwnerRef, nil
+	}
+
+	// Default to returning Pod as the Owner
+	return podOwnerRefs, nil
+}
+
+// findFinalOwnerRef tries to locate the final controller/owner based on the owner reference provided.
+func findFinalOwnerRef(ctx context.Context, client crclient.Client, ns string,
+	ownerRef *metav1.OwnerReference) (*metav1.OwnerReference, error) {
+	if ownerRef == nil {
+		return nil, nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(ownerRef.APIVersion)
+	obj.SetKind(ownerRef.Kind)
+	err := client.Get(ctx, types.NamespacedName{Namespace: ns, Name: ownerRef.Name}, obj)
+	if err != nil {
+		return nil, err
+	}
+	newOwnerRef := metav1.GetControllerOf(obj)
+	if newOwnerRef != nil {
+		return findFinalOwnerRef(ctx, client, ns, newOwnerRef)
+	}
+
+	log.V(1).Info("Pods owner found", "Kind", ownerRef.Kind, "Name",
+		ownerRef.Name, "Namespace", ns)
+	return ownerRef, nil
+}

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright Contributors to the Submariner project.
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	monclientv1 "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var ErrServiceMonitorNotPresent = fmt.Errorf("no ServiceMonitor registered with the API")
+
+const openshiftMonitoringNS = "openshift-monitoring"
+
+type ServiceMonitorUpdater func(*monitoringv1.ServiceMonitor) error
+
+// CreateServiceMonitors creates ServiceMonitors objects based on an array of Service objects.
+// If CR ServiceMonitor is not registered in the Cluster it will not attempt at creating resources.
+func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Service) ([]*monitoringv1.ServiceMonitor, error) {
+	// check if we can even create ServiceMonitors
+	exists, err := hasServiceMonitor(config)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, ErrServiceMonitorNotPresent
+	}
+
+	// On OpenShift, we need to create the service monitors in the OpenShift monitoring namespace, not the
+	// services; we need our own clientset rather than the manager's since the latter hasn't started yet
+	// (so its caching infrastructure isn't available, and reads fail)
+	cs, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := cs.CoreV1().Namespaces().Get(context.TODO(), openshiftMonitoringNS, metav1.GetOptions{}); err == nil {
+		ns = openshiftMonitoringNS
+	} else if !errors.IsNotFound(err) {
+		log.Error(err, "Error checking for the OpenShift monitoring namespace")
+	}
+
+	serviceMonitors := make([]*monitoringv1.ServiceMonitor, len(services))
+	mclient := monclientv1.NewForConfigOrDie(config)
+
+	for _, s := range services {
+		if s == nil {
+			continue
+		}
+		sm := GenerateServiceMonitor(ns, s)
+
+		smc, err := mclient.ServiceMonitors(ns).Create(context.TODO(), sm, metav1.CreateOptions{})
+		if err != nil {
+			return serviceMonitors, err
+		}
+		serviceMonitors = append(serviceMonitors, smc)
+	}
+
+	return serviceMonitors, nil
+}
+
+// GenerateServiceMonitor generates a prometheus-operator ServiceMonitor object
+// based on the passed Service object.
+func GenerateServiceMonitor(ns string, s *v1.Service) *monitoringv1.ServiceMonitor {
+	labels := make(map[string]string)
+	for k, v := range s.ObjectMeta.Labels {
+		labels[k] = v
+	}
+	endpoints := populateEndpointsFromServicePorts(s)
+	boolTrue := true
+
+	// Owner references only work inside the same namespace
+	ownerReferences := []metav1.OwnerReference{}
+	namespaceSelector := monitoringv1.NamespaceSelector{}
+	if ns == s.ObjectMeta.Namespace {
+		ownerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         "v1",
+				BlockOwnerDeletion: &boolTrue,
+				Controller:         &boolTrue,
+				Kind:               "Service",
+				Name:               s.Name,
+				UID:                s.UID,
+			},
+		}
+	} else {
+		namespaceSelector = monitoringv1.NamespaceSelector{
+			MatchNames: []string{s.ObjectMeta.Namespace},
+		}
+	}
+
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            s.ObjectMeta.Name,
+			Namespace:       ns,
+			Labels:          labels,
+			OwnerReferences: ownerReferences,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			NamespaceSelector: namespaceSelector,
+			Endpoints:         endpoints,
+		},
+	}
+}
+
+func populateEndpointsFromServicePorts(s *v1.Service) []monitoringv1.Endpoint {
+	endpoints := make([]monitoringv1.Endpoint, len(s.Spec.Ports))
+	for _, port := range s.Spec.Ports {
+		endpoints = append(endpoints, monitoringv1.Endpoint{Port: port.Name})
+	}
+	return endpoints
+}
+
+// hasServiceMonitor checks if ServiceMonitor is registered in the cluster.
+func hasServiceMonitor(config *rest.Config) (bool, error) {
+	dc := discovery.NewDiscoveryClientForConfigOrDie(config)
+	apiVersion := "monitoring.coreos.com/v1"
+	kind := "ServiceMonitor"
+
+	return k8sutil.ResourceExists(dc, apiVersion, kind)
+}

--- a/pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go
+++ b/pkg/subctl/operator/common/embeddedyamls/generators/yamls2go.go
@@ -74,6 +74,8 @@ var files = []string{
 	"config/rbac/networkplugin_syncer/service_account.yaml",
 	"config/rbac/networkplugin_syncer/cluster_role.yaml",
 	"config/rbac/networkplugin_syncer/cluster_role_binding.yaml",
+	"config/rbac/submariner-metrics-reader/role.yaml",
+	"config/rbac/submariner-metrics-reader/role_binding.yaml",
 }
 
 // Reads all .yaml files in the crdDirectory

--- a/pkg/subctl/operator/submarinerop/serviceaccount/ensure.go
+++ b/pkg/subctl/operator/submarinerop/serviceaccount/ensure.go
@@ -176,7 +176,13 @@ func ensureRoles(clientSet *clientset.Clientset, namespace string) (bool, error)
 		return false, err
 	}
 
-	return createdOperatorRole || createdSubmarinerRole || createdRouteAgentRole || createdGlobalnetRole, err
+	createdMetricsReaderRole, err := serviceaccount.EnsureRole(clientSet, namespace,
+		embeddedyamls.Config_rbac_submariner_metrics_reader_role_yaml)
+	if err != nil {
+		return false, err
+	}
+
+	return createdOperatorRole || createdSubmarinerRole || createdRouteAgentRole || createdGlobalnetRole || createdMetricsReaderRole, err
 }
 
 func ensureRoleBindings(clientSet *clientset.Clientset, namespace string) (bool, error) {
@@ -204,5 +210,11 @@ func ensureRoleBindings(clientSet *clientset.Clientset, namespace string) (bool,
 		return false, err
 	}
 
-	return createdOperatorRB || createdSubmarinerRB || createdRouteAgentRB || createdGlobalnetRB, err
+	createdMetricsReaderRB, err := serviceaccount.EnsureRoleBinding(clientSet, namespace,
+		embeddedyamls.Config_rbac_submariner_metrics_reader_role_binding_yaml)
+	if err != nil {
+		return false, err
+	}
+
+	return createdOperatorRB || createdSubmarinerRB || createdRouteAgentRB || createdGlobalnetRB || createdMetricsReaderRB, err
 }


### PR DESCRIPTION
This sets up the ServiceMonitors in the OpenShift monitoring namespace
instead of the monitored services’ namespaces, which enables
monitoring as a core service without user configuration.

Fixes: #1299
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
