### PR TITLE
Use clientcmd's built-in flag handling

### DIFF
--- a/pkg/subctl/cmd/benchmark.go
+++ b/pkg/subctl/cmd/benchmark.go
@@ -67,7 +67,7 @@ func init() {
 }
 
 func addBenchmarkFlags(cmd *cobra.Command) {
-	AddKubeContextMultiFlag(cmd, "comma-separated list of one or two kubeconfig contexts to use.")
+	AddKubeContextMultiFlag(cmd)
 	cmd.PersistentFlags().BoolVar(&intraCluster, "intra-cluster", false, "run the test within a single cluster")
 	cmd.PersistentFlags().BoolVar(&benchmark.Verbose, "verbose", false, "produce verbose logs during benchmark tests")
 }

--- a/pkg/subctl/cmd/cloud/aws/aws.go
+++ b/pkg/subctl/cmd/cloud/aws/aws.go
@@ -36,9 +36,9 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"gopkg.in/ini.v1"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -73,7 +73,7 @@ func AddAWSFlags(command *cobra.Command) {
 
 // RunOnAWS runs the given function on AWS, supplying it with a cloud instance connected to AWS and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to AWS.
-func RunOnAWS(gwInstanceType, kubeConfig, kubeContext string,
+func RunOnAWS(gwInstanceType string, clientConfig *clientcmd.ClientConfig,
 	function func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error) error {
 	if ocpMetadataFile != "" {
 		err := initializeFlagsFromOCPMetadata(ocpMetadataFile)
@@ -101,7 +101,7 @@ func RunOnAWS(gwInstanceType, kubeConfig, kubeContext string,
 	ec2Client := ec2.NewFromConfig(cfg)
 	reporter.Succeeded("")
 
-	k8sConfig, err := restconfig.ForCluster(kubeConfig, kubeContext)
+	k8sConfig, err := (*clientConfig).ClientConfig()
 	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
 
 	restMapper, err := util.BuildRestMapper(k8sConfig)

--- a/pkg/subctl/cmd/cloud/cleanup/aws.go
+++ b/pkg/subctl/cmd/cloud/cleanup/aws.go
@@ -42,7 +42,7 @@ func newAWSCleanupCommand() *cobra.Command {
 }
 
 func cleanupAws(cmd *cobra.Command, args []string) {
-	err := aws.RunOnAWS("", *kubeConfig, *kubeContext,
+	err := aws.RunOnAWS("", clientConfig,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			err := gwDeployer.Cleanup(reporter)
 			if err != nil {

--- a/pkg/subctl/cmd/cloud/cleanup/cleanup.go
+++ b/pkg/subctl/cmd/cloud/cleanup/cleanup.go
@@ -20,17 +20,16 @@ package cleanup
 
 import (
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
-	kubeConfig  *string
-	kubeContext *string
+	clientConfig *clientcmd.ClientConfig
 )
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
-	kubeConfig = origKubeConfig
-	kubeContext = origKubeContext
+func NewCommand(origClientConfig *clientcmd.ClientConfig) *cobra.Command {
+	clientConfig = origClientConfig
 	cmd := &cobra.Command{
 		Use:   "cleanup",
 		Short: "Clean up the cloud",

--- a/pkg/subctl/cmd/cloud/cleanup/gcp.go
+++ b/pkg/subctl/cmd/cloud/cleanup/gcp.go
@@ -41,7 +41,7 @@ func newGCPCleanupCommand() *cobra.Command {
 }
 
 func cleanupGCP(cmd *cobra.Command, args []string) {
-	err := gcp.RunOnGCP("", *kubeConfig, *kubeContext, false,
+	err := gcp.RunOnGCP("", clientConfig, false,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			err := gwDeployer.Cleanup(reporter)
 			if err != nil {

--- a/pkg/subctl/cmd/cloud/cleanup/generic.go
+++ b/pkg/subctl/cmd/cloud/cleanup/generic.go
@@ -37,7 +37,7 @@ func newGenericCleanupCommand() *cobra.Command {
 }
 
 func cleanupGenericCluster(cmd *cobra.Command, args []string) {
-	err := generic.RunOnK8sCluster(*kubeConfig, *kubeContext,
+	err := generic.RunOnK8sCluster(clientConfig,
 		func(gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			return gwDeployer.Cleanup(reporter)
 		})

--- a/pkg/subctl/cmd/cloud/cloud.go
+++ b/pkg/subctl/cmd/cloud/cloud.go
@@ -22,18 +22,19 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/cleanup"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/prepare"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
+func NewCommand(clientConfig *clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cloud",
 		Short: "Cloud operations",
 		Long:  `This command contains cloud operations related to Submariner installation.`,
 	}
 
-	cmd.AddCommand(prepare.NewCommand(origKubeConfig, origKubeContext))
-	cmd.AddCommand(cleanup.NewCommand(origKubeConfig, origKubeContext))
+	cmd.AddCommand(prepare.NewCommand(clientConfig))
+	cmd.AddCommand(cleanup.NewCommand(clientConfig))
 
 	return cmd
 }

--- a/pkg/subctl/cmd/cloud/gcp/gcp.go
+++ b/pkg/subctl/cmd/cloud/gcp/gcp.go
@@ -35,12 +35,12 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/option"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -77,7 +77,7 @@ func AddGCPFlags(command *cobra.Command) {
 
 // RunOnGCP runs the given function on GCP, supplying it with a cloud instance connected to GCP and a reporter that writes to CLI.
 // The functions makes sure that infraID and region are specified, and extracts the credentials from a secret in order to connect to GCP.
-func RunOnGCP(gwInstanceType, kubeConfig, kubeContext string, dedicatedGWNodes bool,
+func RunOnGCP(gwInstanceType string, clientConfig *clientcmd.ClientConfig, dedicatedGWNodes bool,
 	function func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error) error {
 	if ocpMetadataFile != "" {
 		err := initializeFlagsFromOCPMetadata(ocpMetadataFile)
@@ -104,7 +104,7 @@ func RunOnGCP(gwInstanceType, kubeConfig, kubeContext string, dedicatedGWNodes b
 	gcpClient, err := gcpClientIface.NewClient(projectID, options)
 	utils.ExitOnError("Failed to initialize a GCP Client", err)
 
-	k8sConfig, err := restconfig.ForCluster(kubeConfig, kubeContext)
+	k8sConfig, err := (*clientConfig).ClientConfig()
 	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
 
 	clientSet, err := kubernetes.NewForConfig(k8sConfig)

--- a/pkg/subctl/cmd/cloud/generic/generic.go
+++ b/pkg/subctl/cmd/cloud/generic/generic.go
@@ -24,13 +24,13 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
 	cloudutils "github.com/submariner-io/submariner-operator/pkg/subctl/cmd/cloud/utils"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
-func RunOnK8sCluster(kubeConfig, kubeContext string,
+func RunOnK8sCluster(clientConfig *clientcmd.ClientConfig,
 	function func(gwDeployer api.GatewayDeployer, reporter api.Reporter) error) error {
-	k8sConfig, err := restconfig.ForCluster(kubeConfig, kubeContext)
+	k8sConfig, err := (*clientConfig).ClientConfig()
 	utils.ExitOnError("Failed to initialize a Kubernetes config", err)
 
 	clientSet, err := kubernetes.NewForConfig(k8sConfig)

--- a/pkg/subctl/cmd/cloud/prepare/aws.go
+++ b/pkg/subctl/cmd/cloud/prepare/aws.go
@@ -62,7 +62,7 @@ func prepareAws(cmd *cobra.Command, args []string) {
 		input.InternalPorts = append(input.InternalPorts, gwPorts...)
 	}
 
-	err := aws.RunOnAWS(awsGWInstanceType, *kubeConfig, *kubeContext,
+	err := aws.RunOnAWS(awsGWInstanceType, clientConfig,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/gcp.go
+++ b/pkg/subctl/cmd/cloud/prepare/gcp.go
@@ -59,7 +59,7 @@ func prepareGCP(cmd *cobra.Command, args []string) {
 		},
 	}
 
-	err := gcp.RunOnGCP(gcpGWInstanceType, *kubeConfig, *kubeContext, dedicatedGateway,
+	err := gcp.RunOnGCP(gcpGWInstanceType, clientConfig, dedicatedGateway,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/generic.go
+++ b/pkg/subctl/cmd/cloud/prepare/generic.go
@@ -39,7 +39,7 @@ func newGenericPrepareCommand() *cobra.Command {
 }
 
 func prepareGenericCluster(cmd *cobra.Command, args []string) {
-	err := generic.RunOnK8sCluster(*kubeConfig, *kubeContext,
+	err := generic.RunOnK8sCluster(clientConfig,
 		func(gwDeployer api.GatewayDeployer, reporter api.Reporter) error {
 			if gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/subctl/cmd/cloud/prepare/prepare.go
+++ b/pkg/subctl/cmd/cloud/prepare/prepare.go
@@ -20,6 +20,7 @@ package prepare
 
 import (
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
@@ -27,8 +28,7 @@ var (
 	natDiscoveryPort uint16
 	vxlanPort        uint16
 	metricsPort      uint16
-	kubeConfig       *string
-	kubeContext      *string
+	clientConfig     *clientcmd.ClientConfig
 )
 
 var (
@@ -41,9 +41,8 @@ var (
 const DefaultNumGateways = 1
 
 // NewCommand returns a new cobra.Command used to prepare a cloud infrastructure
-func NewCommand(origKubeConfig, origKubeContext *string) *cobra.Command {
-	kubeConfig = origKubeConfig
-	kubeContext = origKubeContext
+func NewCommand(origClientConfig *clientcmd.ClientConfig) *cobra.Command {
+	clientConfig = origClientConfig
 	cmd := &cobra.Command{
 		Use:   "prepare",
 		Short: "Prepare the cloud",

--- a/pkg/subctl/cmd/deploybroker.go
+++ b/pkg/subctl/cmd/deploybroker.go
@@ -26,7 +26,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/stringset"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/components"
 	v1 "k8s.io/api/core/v1"
 
@@ -73,7 +72,7 @@ func init() {
 
 	deployBroker.PersistentFlags().BoolVar(&operatorDebug, "operator-debug", false, "enable operator debugging (verbose logging)")
 
-	AddKubeContextFlag(deployBroker)
+	addKubeContextFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
 }
 
@@ -97,7 +96,7 @@ var deployBroker = &cobra.Command{
 		if valid, err := isValidGlobalnetConfig(); !valid {
 			utils.ExitOnError("Invalid GlobalCIDR configuration", err)
 		}
-		config, err := restconfig.ForCluster(kubeConfig, kubeContext)
+		config, err := getRestConfig()
 		utils.ExitOnError("The provided kubeconfig is invalid", err)
 
 		status := cli.NewStatus()

--- a/pkg/subctl/cmd/diagnose/firewall_tunnel.go
+++ b/pkg/subctl/cmd/diagnose/firewall_tunnel.go
@@ -64,16 +64,6 @@ func init() {
 	addDiagnoseFWConfigFlags(command)
 	addVerboseFlag(command)
 	diagnoseFirewallConfigCmd.AddCommand(command)
-
-	deprecatedCommand := &cobra.Command{
-		Use:        "tunnel <localkubeconfig> <remotekubeconfig>",
-		Deprecated: "please use inter-cluster",
-		Short:      command.Short,
-		Long:       command.Long,
-		Args:       command.Args,
-		Run:        command.Run,
-	}
-	diagnoseFirewallConfigCmd.AddCommand(deprecatedCommand)
 }
 
 func validateTunnelConfig(command *cobra.Command, args []string) {

--- a/pkg/subctl/cmd/diagnose/firewall_vxlan.go
+++ b/pkg/subctl/cmd/diagnose/firewall_vxlan.go
@@ -44,16 +44,6 @@ func init() {
 	addDiagnoseFWConfigFlags(command)
 	addVerboseFlag(command)
 	diagnoseFirewallConfigCmd.AddCommand(command)
-
-	deprecatedCommand := &cobra.Command{
-		Use:        "vxlan",
-		Deprecated: "please use intra-cluster",
-		Short:      command.Short,
-		Long:       command.Long,
-		Args:       command.Args,
-		Run:        command.Run,
-	}
-	diagnoseFirewallConfigCmd.AddCommand(deprecatedCommand)
 }
 
 func checkVxLANConfig(cluster *cmd.Cluster) bool {

--- a/pkg/subctl/cmd/export.go
+++ b/pkg/subctl/cmd/export.go
@@ -66,7 +66,7 @@ func exportService(cmd *cobra.Command, args []string) {
 	err := validateArguments(args)
 	utils.ExitOnError("Insufficient arguments", err)
 
-	clientConfig := restconfig.ClientConfig(kubeConfig, kubeContext)
+	clientConfig := getClientConfig()
 	restConfig, err := clientConfig.ClientConfig()
 
 	utils.ExitOnError("Error connecting to the target cluster", err)

--- a/pkg/subctl/cmd/gather/gather.go
+++ b/pkg/subctl/cmd/gather/gather.go
@@ -73,7 +73,7 @@ var gatherFuncs = map[string]func(string, Info) bool{
 }
 
 func init() {
-	cmd.AddKubeContextMultiFlag(gatherCmd, "")
+	cmd.AddKubeContextMultiFlag(gatherCmd)
 	addGatherFlags(gatherCmd)
 	cmd.AddToRootCommand(gatherCmd)
 }

--- a/pkg/subctl/cmd/join.go
+++ b/pkg/subctl/cmd/join.go
@@ -86,7 +86,7 @@ var (
 
 func init() {
 	addJoinFlags(joinCmd)
-	AddKubeContextFlag(joinCmd)
+	addKubeContextFlag(joinCmd)
 	rootCmd.AddCommand(joinCmd)
 }
 
@@ -156,8 +156,8 @@ var joinCmd = &cobra.Command{
 		utils.ExitOnError("Error connecting to broker cluster", err)
 		err = isValidCustomCoreDNSConfig()
 		utils.ExitOnError("Invalid Custom CoreDNS configuration", err)
-		config := restconfig.ClientConfig(kubeConfig, kubeContext)
-		joinSubmarinerCluster(config, kubeContext, subctlData)
+		config := getClientConfig()
+		joinSubmarinerCluster(config, subctlData)
 	},
 }
 
@@ -170,7 +170,7 @@ func checkArgumentPassed(args []string) error {
 
 var status = cli.NewStatus()
 
-func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, subctlData *datafile.SubctlData) {
+func joinSubmarinerCluster(config clientcmd.ClientConfig, subctlData *datafile.SubctlData) {
 	// Missing information
 	var qs = []*survey.Question{}
 
@@ -178,7 +178,7 @@ func joinSubmarinerCluster(config clientcmd.ClientConfig, contextName string, su
 		rawConfig, err := config.RawConfig()
 		// This will be fatal later, no point in continuing
 		utils.ExitOnError("Error connecting to the target cluster", err)
-		clusterName := restconfig.ClusterNameFromContext(rawConfig, contextName)
+		clusterName := getClusterNameFromContext(rawConfig)
 		if clusterName != nil {
 			clusterID = *clusterName
 		}

--- a/pkg/subctl/cmd/verify.go
+++ b/pkg/subctl/cmd/verify.go
@@ -36,7 +36,6 @@ import (
 	"github.com/submariner-io/shipyard/test/e2e"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils"
-	"github.com/submariner-io/submariner-operator/pkg/subctl/cmd/utils/restconfig"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
 	_ "github.com/submariner-io/submariner/test/e2e/redundancy"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -59,7 +58,7 @@ var (
 )
 
 func init() {
-	AddKubeContextMultiFlag(verifyCmd, "comma-separated list of exactly two kubeconfig contexts to use.")
+	AddKubeContextMultiFlag(verifyCmd)
 	verifyCmd.Flags().StringVar(&verifyOnly, "only", strings.Join(getAllVerifyKeys(), ","), "comma separated verifications to be performed")
 	verifyCmd.Flags().BoolVar(&disruptiveTests, "disruptive-tests", false, "enable disruptive verifications like gateway-failover")
 	addVerifyFlags(verifyCmd)
@@ -201,9 +200,9 @@ func configureTestingFramework(args []string) error {
 }
 
 func clusterNameFromConfig(kubeConfigPath, kubeContext string) string {
-	rawConfig, err := restconfig.ClientConfig(kubeConfigPath, "").RawConfig()
-	utils.ExitOnError(fmt.Sprintf("Error obtaining the kube config for path %q", kubeConfigPath), err)
-	cluster := restconfig.ClusterNameFromContext(rawConfig, kubeContext)
+	rawConfig, err := getClientConfig().RawConfig()
+	exitOnError(fmt.Sprintf("Error obtaining the kube config for path %q", kubeConfigPath), err)
+	cluster := getClusterNameFromContext(rawConfig)
 
 	if cluster == nil {
 		utils.ExitWithErrorMsg(fmt.Sprintf("Could not obtain the cluster name from kube config: %#v", rawConfig))


### PR DESCRIPTION
This reduces the amount of flag-handling code we need to carry,
shields us from changes to clientcmd, and enables a host of other
flags which can be useful to connect to Kubernetes clusters.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
